### PR TITLE
docs(marketing): 30-day beta growth plan + paid/content/video execution docs

### DIFF
--- a/marketing/30-day-beta-growth-plan.md
+++ b/marketing/30-day-beta-growth-plan.md
@@ -1,0 +1,219 @@
+# Clue / ChronicLife — 30-Day Beta Growth Plan
+
+> **Goal (you chose this):** Get **engaged users who actually chat & log** — not vanity signups.
+> **Focus channels:** Paid ads (Reddit + Meta) done right · Content/SEO + AI-search · Short-form video.
+> **Budget:** $500/month paid.
+> **Owner:** Niranjan (Founder/CEO) · **Drafted:** June 11, 2026 · **Status:** Active plan.
+
+---
+
+## 0. The honest diagnosis
+
+Your last Reddit run (`The Clarity Experiment`, ~$100) got **~12 signups**. That's not a failure — it was a *measurement* experiment, and $100 of cold paid traffic to a pre-PMF free product will always be thin. The lesson isn't "Reddit ads don't work," it's **"$100 of cold paid clicks can't be your growth engine."**
+
+For a free, emotionally-driven health product targeting Spoonies, the people most likely to *actually chat and log* come from **trust-rich contexts** — communities they already belong to, content that already answers their question, and faces/voices that feel like one of their own. So this plan weights effort toward **earned + organic-amplified-by-paid**, with paid used as a *targeted accelerant*, not the whole machine.
+
+### What you already have (don't rebuild it)
+- **Supabase `campaign_config`** table + `/tracking` dashboard + UTM conventions (`utm_source/medium/campaign/content`).
+- **Product-specific landing pages:** `/spoon-saver`, `/flare-forecast`, `/top-suspect`, `/crash-prevention` — each a different *angle* you can A/B at the page level.
+- Live campaign `spoon_saver_v3` with 7 ad variants already defined.
+- Ad **videos** (ad1, ad2, ad3 + v2/v3 variants) sitting in `context/`.
+- A `marketing-campaigns` skill that writes ads + generates tracking URLs automatically.
+- Connectors live: **Google Ads, Facebook Pages, PostHog, GA4, Semrush, Canva, YouTube, Klaviyo, HubSpot, Notion, GitHub**.
+
+---
+
+## 1. The North Star: define "engaged" before spending a dollar
+
+You said the goal is engaged users. So the metric we optimize is **NOT signups** — it's the activation funnel:
+
+```
+Visit  →  Signup/started  →  First Chat (Clue replies)  →  First Symptom Logged  →  Day-3 Return  →  Day-7 Return
+```
+
+### Activation metric (the one number)
+> **% of signups who log at least one symptom AND return at least once within 7 days ("Activated Beta User", ABU).**
+
+Everything in this plan is judged by **cost-per-ABU and ABU count**, not raw signups. A channel that brings 5 signups where 4 activate beats a channel that brings 30 signups where 2 activate.
+
+### Tracking plan (instrument this in PostHog — most can already be wired via your Supabase events)
+| Event | Where | Why |
+|---|---|---|
+| `landing_visit` (already tracked) | landing pages | top of funnel + UTM attribution |
+| `signup_started` / `signup_completed` | auth modal | signup conversion |
+| `first_chat_sent` | chat surface | the real activation trigger |
+| `first_symptom_logged` | graph/log | the value moment |
+| `knowledge_graph_viewed` | sidebar | the "aha" — this is your differentiator |
+| `return_day_3`, `return_day_7` | session | retention |
+
+**Action:** Create a PostHog **funnel insight** for these 6 steps, broken down by `utm_campaign` + `utm_content`. This becomes your single source of truth for *which message produces engaged users*, not just clicks. (I can create this insight via the PostHog connector — see Section 8.)
+
+---
+
+## 2. Positioning lock (so every channel says the same thing)
+
+Your research already converged: **prediction is the #1 validated desire**, ahead of trigger-ID and doctor communication. The landing page hero already reflects this ("Learns your patterns, adapts to your energy").
+
+**Primary promise (lead with this everywhere):**
+> *"Predict your next flare before it hits — by chatting for 20 seconds a day."*
+
+**Three supporting angles** (map 1:1 to your existing landing pages — let the page do the A/B work):
+| Angle | Pain | Landing page | Best channel |
+|---|---|---|---|
+| **Prediction / Pattern** | "I'm blindsided by flares" | `/flare-forecast`, `/top-suspect` | Meta (visual pattern reveal), short-form video |
+| **Low-effort / Spoons** | "Tracking costs energy I don't have" | `/spoon-saver` | Reddit (community language), short-form |
+| **Doctor proof** | "My doctor dismisses me" | `/crash-prevention` (or build `/doctor-pack`) | Google Search (high intent), content/SEO |
+
+**Voice:** keep the Spoonie-copywriter "Language of Care" — validation over instruction, permission over restriction, neutral over judgmental. This is your unfair advantage; bigger competitors (Bearable, Guava, Visible) sound clinical.
+
+---
+
+## 3. The 30-day plan at a glance
+
+| Week | Paid ($500/mo ≈ $115/wk) | Content / SEO / AI-search | Short-form video | Community (organic, free) |
+|---|---|---|---|---|
+| **Week 1 — Foundation** | Set up Meta pixel + conversions API; rebuild Reddit campaign w/ new creative; **don't spend yet** | Publish 1 cornerstone comparison page + `llms.txt` + `/pricing.md`; submit sitemap | Film/edit 3 vertical clips from existing ad videos + 1 founder talking-head | Warm up: comment authentically in 5 target subreddits, no links |
+| **Week 2 — Launch** | Launch Meta ($8/day) + Reddit ($8/day) split-test, prediction vs spoons angle | Publish 2 long-tail "answer" articles targeting AI-search queries | Post 4 clips (TikTok + Reels + Shorts), reply to every comment | 1 genuine value post in r/ChronicIllness or r/cfs (story, not pitch) |
+| **Week 3 — Read & cut** | Kill bottom 50% of ads by **cost-per-ABU**; shift budget to winner angle | Publish 2 more articles; internal-link cluster; pitch 1 guest post / Reddit AMA | Double down on best-performing clip format; 4 more posts | Engage Discord/FB groups; soft-launch a founder "build in public" thread |
+| **Week 4 — Scale winner** | Scale the single winning ad set 20–30%; add retargeting of site visitors | Refresh top article w/ stats + FAQ schema; measure AI citations | 4 posts; 1 longer-form YouTube explainer ("how flare prediction works") | Recruit 3–5 most-engaged users as "founding members" for testimonials |
+
+**Weekly ritual (your 8am standup fits perfectly):** every Monday, pull the PostHog ABU-funnel by `utm_content`, log it to the repo, kill losers, scale winners. I can automate this as a cron (Section 9).
+
+---
+
+## 4. PAID — $500/month, done right
+
+### Why Meta + Reddit (and a sliver of Google), not just Reddit
+- **Reddit** = where Spoonies *talk*; great for resonance + cheap clicks, but lower conversion-to-action and clunky pixel. Keep it, but cap it.
+- **Meta (FB/IG)** = best creative + retargeting + lookalikes; your prediction angle is *visual* (knowledge graph, flare forecast) which Meta rewards. This should be your primary paid engine.
+- **Google Search** = tiny but **highest-intent**: people typing "symptom tracker for chronic illness" or "app to track flares" are bottom-funnel. A $2/day search campaign on 10 exact keywords can produce your best-activating users.
+
+### Budget split (testing phase, Weeks 2–3)
+| Channel | Daily | Monthly | Objective | Optimized for |
+|---|---|---|---|---|
+| **Meta** | $8 | ~$240 | Conversions (signup/first_chat) | cost-per-ABU |
+| **Reddit** | $6 | ~$180 | Traffic → conversion | CTR + activation |
+| **Google Search** | $2.50 | ~$75 | High-intent capture | conversions |
+| *Reserve* | — | ~$5 | buffer | — |
+
+After Week 3, **consolidate into the single best channel/angle** (scaling phase: one winner gets the budget).
+
+### The #1 thing that will 3x your results: **conversion tracking + a real CTA**
+Two pre-launch blockers from the audit:
+1. **Landing page CTA isn't clearly visible** in the page content I pulled. Every paid landing page needs ONE obvious above-the-fold CTA ("Start a 20-second check-in") that goes straight into chat — no friction, no long signup. *Fix before spending.*
+2. **Meta Pixel + Conversions API** must fire `signup_completed` and `first_chat_sent`. Without this, Meta optimizes for clicks (cheap, useless) instead of engaged users. *This is the single highest-leverage setup task.*
+
+**Pre-launch checklist (do all before $1 is spent):**
+- [ ] Meta Pixel installed + Conversions API + `signup` and `first_chat` events
+- [ ] Google Ads conversion tag on signup
+- [ ] Every ad URL uses the UTM convention (Section 6) so PostHog attributes ABUs
+- [ ] One clear CTA above the fold on each landing page
+- [ ] Mobile load < 3s (most Spoonies browse on phone in bed)
+- [ ] Reddit ads re-pointed to new creative (Section 5)
+
+> Detailed campaign builds, ad copy, targeting, and the exact Reddit + Meta + Google structures are in **`paid-ads-campaign.md`**.
+
+---
+
+## 5. CONTENT / SEO + AI-SEARCH
+
+Spoonies are *researchers* — they Google and now ChatGPT/Perplexity their symptoms constantly. Getting **cited by AI answers** and ranking for long-tail health-tracking queries is the cheapest durable engine you have. (Per Princeton GEO research, citing sources +40% and adding statistics +37% to AI citation rates.)
+
+### Three content types that get cited most (prioritize these)
+1. **Comparison pages** (~33% of AI citations): *"Bearable vs ChronicLife"*, *"Best symptom trackers for chronic illness 2026"*, *"Guava vs Visible vs ChronicLife"*. High-intent, structured, AI-friendly.
+2. **Definitive guides**: *"How to track symptoms when you have brain fog"*, *"How to predict a chronic illness flare"*.
+3. **Original data/research**: you sit on a goldmine — anonymized aggregate patterns ("Across N Clue users, fatigue rose 40% after <6h sleep"). Original stats get cited 37–40% more.
+
+### Technical AI-search must-dos (Week 1)
+- Add **`/llms.txt`** (product overview + key links) and **`/pricing.md`** ("Free during beta") to site root.
+- Confirm **robots.txt allows** GPTBot, PerplexityBot, ClaudeBot, Google-Extended (blocking them = can't be cited).
+- Add **FAQPage + Article + Product schema** to landing + content pages.
+- Lead every article section with a **40–60 word self-contained answer block**.
+
+> The full content calendar, the first 3 publishable article drafts, target queries, and schema templates are in **`content-seo-ai-search-plan.md`**.
+
+---
+
+## 6. UTM & tracking convention (extends your existing system)
+
+Keep your existing pattern; just add the new sources so PostHog attributes everything cleanly:
+
+```
+https://chroniclife.app/{product}?utm_source={source}&utm_medium={medium}&utm_campaign={campaign}&utm_content={content_id}
+```
+
+| Channel | utm_source | utm_medium | Example campaign |
+|---|---|---|---|
+| Meta paid | `meta` | `paid` | `flare_predict_v1` |
+| Reddit paid | `reddit` | `paid` | `spoon_saver_v4` |
+| Google Search | `google` | `cpc` | `intent_capture_v1` |
+| TikTok/Reels/Shorts (bio/organic) | `tiktok` / `instagram` / `youtube` | `social` | `shortform_v1` |
+| Blog/SEO | `blog` | `organic` | `content_v1` |
+| Reddit organic posts | `reddit` | `social` | `community_v1` |
+
+Each new ad → a row in `campaign_config` (your skill does this) so `/tracking` + PostHog stay the source of truth.
+
+---
+
+## 7. SHORT-FORM VIDEO
+
+You already have ad videos — repurpose them into vertical, captioned, native-feeling clips. Spoonie TikTok ("chronic illness TikTok") is huge and high-empathy.
+
+- **Format:** 9:16, captions always (85% watch muted), first 3s = pattern interrupt.
+- **3 proven hook angles:** (1) "POV: you forgot your symptoms again because brain fog" (2) "I tracked my flares for 14 days and the app predicted the next one" (3) "Things my doctor finally believed once I showed them this."
+- **Cadence:** 4 posts/week across TikTok + Reels + Shorts (same clip, 3 platforms).
+- **Founder build-in-public:** 1 talking-head/week — founders in this niche build trust fast.
+
+> Full hook bank, 8 ready-to-shoot scripts, and an editing spec are in **`short-form-video-plan.md`**.
+
+---
+
+## 8. COMMUNITY (free, highest-trust — runs alongside everything)
+
+Paid gets you clicks; community gets you *believers* who activate and tell friends.
+- **Warm up first** (Week 1): comment helpfully in r/ChronicIllness, r/cfs, r/Fibromyalgia, r/LongCOVID, r/POTS, r/ChronicPain with **zero links** — build karma + read the room.
+- **Value posts, not pitches:** share a genuinely useful insight ("here's how I finally got my doctor to listen") and mention the tool only if asked / in comments.
+- **Founding-members program** (Week 4): turn your 3–5 most engaged beta users into named testimonials + a private feedback channel (Discord). This is your retention + word-of-mouth flywheel.
+- Most subreddits ban overt promotion — **always read each subreddit's self-promo rules** before posting. Authenticity is the strategy.
+
+---
+
+## 9. Recommended connectors & automations
+
+**Already connected — let's use them:**
+- **PostHog** → build the ABU activation funnel + weekly insight (I can create this now).
+- **Google Ads / Facebook Pages** → launch + report on campaigns programmatically.
+- **GA4** → blended attribution cross-check.
+- **Semrush** → keyword + AI-overview tracking for the content plan.
+- **Canva** → generate ad creative + carousels at scale.
+- **YouTube Data** → publish/repurpose video.
+- **GitHub** → this repo stays the marketing log (done — see `/marketing/`).
+- **Notion** → optional: mirror the weekly dashboard for stakeholders.
+
+**Worth connecting:**
+- **Reddit Ads** (no native connector yet — manage in-platform; I'll prep all creative + targeting).
+- **TikTok** (for organic posting cadence; manual for now).
+- **YouTube Analytics** (currently disconnected) → connect to measure Shorts performance.
+
+**Automations I can set up (with your OK — each cron run uses credits):**
+1. **Weekly Monday 8am "Growth Standup"** — pull PostHog ABU funnel by `utm_content`, Google Ads + Meta spend/results, write the week's log to the repo, and notify you with kill/scale recommendations.
+2. **Monthly AI-visibility check** — query ChatGPT/Perplexity/Google for your 15 priority queries, log whether ChronicLife is cited vs competitors.
+
+---
+
+## 10. Success criteria for the 30 days
+
+| Metric | Floor | Target | Stretch |
+|---|---|---|---|
+| Activated Beta Users (ABU) | 25 | 60 | 120 |
+| Cost per ABU (paid) | < $20 | < $10 | < $6 |
+| First-chat rate (of signups) | 50% | 65% | 75% |
+| Day-7 return rate | 20% | 35% | 50% |
+| AI-search citations (of 15 queries) | 1 | 4 | 8 |
+| Winning angle identified | — | yes | yes + 2nd validated |
+
+The real deliverable at Day 30 is **clarity + a repeatable engine**: one proven angle, one proven channel, a known cost-per-engaged-user, and content compounding in the background.
+
+---
+
+*This plan is the index. Detailed execution lives in: `paid-ads-campaign.md`, `content-seo-ai-search-plan.md`, `short-form-video-plan.md`. All committed to the repo under `/marketing/`.*

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -1,0 +1,28 @@
+# Marketing — Knowledge Base & Record Log
+
+> This folder is the living marketing record for **ChronicLife / Clue**. Treat it as the single source of truth for strategy, campaigns, and results. Update it every week.
+
+## Contents
+| File | Purpose |
+|---|---|
+| [`30-day-beta-growth-plan.md`](./30-day-beta-growth-plan.md) | **Start here.** The master 30-day GTM plan: goal, North Star metric, channel strategy, weekly calendar, success criteria. |
+| [`paid-ads-campaign.md`](./paid-ads-campaign.md) | Ready-to-ship paid campaigns (Meta + Reddit + Google), copy, targeting, $500/mo budget split, optimization rules. |
+| [`content-seo-ai-search-plan.md`](./content-seo-ai-search-plan.md) | Content calendar, 15 target queries, AI-search/GEO technical setup, first cornerstone articles. |
+| [`short-form-video-plan.md`](./short-form-video-plan.md) | TikTok/Reels/Shorts strategy, hook bank, 8 ready-to-shoot scripts. |
+| `weekly-logs/` | Weekly growth-standup results (ABU funnel, spend, kill/scale decisions). Added each Monday. |
+
+## Context (June 11, 2026)
+- **Goal:** engaged beta users who actually chat & log (Activated Beta Users), not vanity signups.
+- **Budget:** $500/month paid.
+- **Focus:** paid (done right) + content/SEO + AI-search + short-form video.
+- **Prior result:** ~12 signups from ~$100 Reddit ads (`The Clarity Experiment`).
+- **Positioning lock:** "Predict your next flare before it hits — by chatting for 20 seconds a day."
+
+## North Star metric
+**Activated Beta User (ABU)** = a signup who logs ≥1 symptom AND returns ≥once within 7 days.
+Optimize every channel by **cost-per-ABU and ABU count**, never raw signups.
+
+## How this connects to existing infra
+- Ads/UTMs flow through the existing Supabase `campaign_config` table + `/tracking` dashboard (see `.claude-skills/marketing-campaigns/`).
+- Attribution: UTM → `landing_visits` → PostHog ABU funnel.
+- Live landing pages: `/spoon-saver`, `/flare-forecast`, `/top-suspect`, `/crash-prevention`.

--- a/marketing/content-seo-ai-search-plan.md
+++ b/marketing/content-seo-ai-search-plan.md
@@ -1,0 +1,110 @@
+# Content / SEO + AI-Search Plan
+
+> Companion to `30-day-beta-growth-plan.md`. Goal: durable, compounding discovery — rank for long-tail health-tracking queries AND get cited by ChatGPT / Perplexity / Google AI Overviews.
+> Drafted June 11, 2026.
+
+---
+
+## Why this matters for Clue specifically
+Spoonies are *researchers*. They Google and now AI-search their symptoms, their conditions, and "best app for X" constantly. Two facts drive the strategy:
+- **~45% of Google searches now show AI Overviews**; ChatGPT/Perplexity are where high-agency patients (your "health detective" persona, Emily) increasingly go first.
+- **Comparison articles = ~33% of AI citations; original data/stats add +37–40% citation rate** (Princeton GEO research). You have both: a clear competitor set AND proprietary aggregate data.
+
+---
+
+## Part A — Technical foundation (Week 1, one-time)
+
+1. **`/llms.txt`** at site root — short machine-readable overview:
+   ```
+   # ChronicLife (app) — Clue (AI agent)
+   Chat-first symptom tracker for people with chronic illness. Predicts flares from
+   20-second daily chats; shows a knowledge graph connecting symptoms → triggers →
+   patterns; exports doctor-ready summaries. Free during beta.
+   Key pages: /flare-forecast, /spoon-saver, /crash-prevention, /
+   ```
+2. **`/pricing.md`** at site root:
+   ```
+   # Pricing — ChronicLife
+   ## Beta (current)
+   - Price: $0 — free during beta
+   - Includes: chat tracking, flare prediction, knowledge graph, doctor summaries
+   ```
+3. **robots.txt**: confirm `GPTBot`, `ChatGPT-User`, `PerplexityBot`, `ClaudeBot`, `Google-Extended`, `Bingbot` are **allowed**. Blocking = can't be cited.
+4. **Schema markup**: `Article` + `FAQPage` on every content page; `Product` + `Organization` on landing pages. (Use the `schema` skill for implementation.)
+5. **Sitemap** submitted to Google Search Console; ensure content renders without heavy JS (AI crawlers + agents read the DOM).
+
+---
+
+## Part B — Target queries (the 15 to win)
+
+Tested across Google / ChatGPT / Perplexity. Track monthly: are we cited? who else is?
+
+**Comparison (highest citation value):**
+1. best symptom tracker for chronic illness 2026
+2. Bearable alternatives
+3. Bearable vs ChronicLife
+4. best app to track fibromyalgia symptoms
+5. symptom tracker for Long COVID
+6. best flare tracking app
+
+**How-to / guide (definitive content):**
+7. how to track symptoms with brain fog
+8. how to predict a chronic illness flare
+9. how to track symptoms for a doctor's appointment
+10. easiest way to track symptoms when fatigued
+11. how to find my chronic illness triggers
+
+**Category / definition:**
+12. what is the best chronic illness app
+13. chat-based symptom tracker
+14. symptom tracker that predicts flares
+15. low-effort symptom tracking app
+
+> Use the **Semrush connector** to pull volumes/difficulty and confirm AI-Overview presence for each. Use **Google Ads keyword ideas** as a cross-check (already available).
+
+---
+
+## Part C — First content to publish (priority order)
+
+### Cornerstone #1 (Week 1): "Best Symptom Trackers for Chronic Illness in 2026 (Honest Comparison)"
+- **Type:** comparison (most-cited format). Include ChronicLife + Bearable + Guava + Visible + Symple + paper journals.
+- **Structure:** 40–60 word answer block up top → comparison table → per-app pros/cons → "best for [use case]" verdicts → FAQ (schema).
+- **Why it wins:** captures #1, #2, #6, #12; gets cited because it's structured + balanced + names entities. Be genuinely fair (AI rewards balance) — ChronicLife wins on "lowest effort / prediction / chat," not on "most features."
+- **Comparison table columns:** Logging effort · Predicts flares? · Chat or forms? · Doctor export? · Free tier · Best for.
+
+### Cornerstone #2 (Week 2): "How to Track Symptoms When You Have Brain Fog"
+- **Type:** definitive guide. Targets #7, #10. Deeply empathetic (Spoonie-copywriter voice).
+- Lead with the validation ("If detailed journaling has failed you, that's not a discipline problem — it's a design problem"), then practical low-effort methods, then how chat-based tracking solves it.
+
+### Cornerstone #3 (Week 2): "How to Get Your Doctor to Take Your Symptoms Seriously"
+- **Type:** guide + original framing. Targets #9. Maps to the Doctor-proof angle + `/crash-prevention` page.
+- Include a downloadable/exportable "doctor summary" example → natural product tie-in.
+
+### Original-data piece (Week 3–4): "What 14 Days of Symptom Data Reveals About Flares"
+- **Type:** original research (highest trust/citation). Use anonymized aggregate Clue data.
+- Pull 3–5 real stats ("X% of users' worst fatigue followed <6h sleep within 24–48h"). **Original stats are your unfair AI-citation advantage** — nobody else has this data.
+- *Privacy:* aggregate-only, no individual data, clear methodology note.
+
+---
+
+## Part D — Presence beyond your own site (where AI actually looks)
+AI cites third-party sources **6.5x more** than your own domain. So:
+- **Reddit** (1.8% of all ChatGPT citations): authentic, helpful answers in r/ChronicIllness etc. (see community section — no spam).
+- **YouTube** (heavily cited by Google AI Overviews): the explainer video from `short-form-video-plan.md` doubles as AI-citation fuel.
+- **Review sites**: get listed on Product Hunt, AlternativeTo (as a Bearable alternative), and relevant app directories.
+- **Quora**: answer "best symptom tracker" / "how to track chronic illness" questions with genuine depth.
+
+---
+
+## Part E — Cadence & measurement
+- **Publish 1–2 articles/week** for the month (5–6 total cornerstone pieces).
+- **Internal-link** all pieces into a cluster pointing to the relevant landing pages.
+- **Refresh** the comparison piece monthly (freshness = AI weights recency heavily; show "Last updated").
+- **Measure:** monthly manual AI-visibility check on the 15 queries (or automate via cron, Section 9 of main plan) + Semrush AI-Overview tracking + GA4 referral traffic from AI sources (`chat.openai.com`, `perplexity.ai`).
+
+---
+
+## What I can do next via connectors
+- **Semrush**: pull volume/difficulty + AI-Overview data for the 15 queries → finalize priority.
+- **Draft the full cornerstone #1 comparison article** (ready to publish), with schema markup included.
+- **Google Docs**: drop drafts there for your review/editing.

--- a/marketing/paid-ads-campaign.md
+++ b/marketing/paid-ads-campaign.md
@@ -1,0 +1,192 @@
+# Paid Ads Campaign — Ready to Ship ($500/mo)
+
+> Companion to `30-day-beta-growth-plan.md`. Optimized for **cost-per-Activated-Beta-User (ABU)**, not clicks.
+> Drafted June 11, 2026. All ads route through the existing `campaign_config` + UTM system.
+
+---
+
+## 0. PRE-LAUNCH GATES (do not spend until all ✅)
+
+1. **Meta Pixel + Conversions API live**, firing `signup_completed` + `first_chat_sent`. This makes Meta optimize for engaged users, not cheap clicks. **Highest-leverage task in the whole plan.**
+2. **Google Ads conversion action** on signup, imported.
+3. **Clear above-the-fold CTA** on each landing page → straight into chat ("Start a 20-second check-in").
+4. **Mobile load < 3s** (Spoonies browse on phones, in bed, fatigued).
+5. **UTMs verified** end-to-end: click an ad → confirm `landing_visit` row in Supabase with correct `utm_content`.
+
+---
+
+## 1. Budget & structure (testing phase, Weeks 2–3)
+
+| Platform | Daily | Objective | Optimize for | Why |
+|---|---|---|---|---|
+| Meta (FB/IG) | $8 | Conversions | `first_chat_sent` | Visual prediction angle + retargeting + lookalikes; primary engine |
+| Reddit | $6 | Traffic→conv | CTR then activation | Native Spoonie language; cheap resonance test |
+| Google Search | $2.50 | Conversions | signup | Tiny spend, highest intent, best activators |
+
+After Week 3 → **consolidate budget into the single best channel × angle** (cost-per-ABU winner).
+
+Naming convention: `[PLATFORM]_[Objective]_[Audience]_[Angle]_[Date]`
+e.g. `META_Conv_LongCOVID_Prediction_2026-06`.
+
+---
+
+## 2. META campaign (primary)
+
+**Campaign:** `META_Conv_Chronic_2026-06` · Objective: **Conversions** (optimize `first_chat_sent`, fallback `signup_completed`).
+
+### Ad sets (2 to start — test ANGLE, the biggest lever)
+| Ad set | Audience | Landing page | UTM |
+|---|---|---|---|
+| **AS1 — Prediction** | Interests: chronic illness, fibromyalgia, Long COVID, POTS, autoimmune, spoonie; Age 25–55; broad placements (Reels + Feed + Stories) | `/flare-forecast` | `utm_source=meta&utm_medium=paid&utm_campaign=flare_predict_v1&utm_content={ad}` |
+| **AS2 — Spoons/Low-effort** | Same interests + "chronic fatigue", "invisible illness" | `/spoon-saver` | `utm_source=meta&utm_medium=paid&utm_campaign=spoon_saver_v4&utm_content={ad}` |
+
+Each ad set = **3 ads** (rotate concepts, never 1 ad/set).
+
+### Meta ad copy — AS1 Prediction (route to `/flare-forecast`)
+
+**Ad 1 — `predict_blindsided`**
+- Primary text: *"Blindsided by another flare? Your body leaves clues before a crash — you just can't see them in the moment. ChronicLife learns your patterns from 20-second daily chats and gives you a heads-up before the next one hits. Free during beta."*
+- Headline: **Predict your next flare**
+- Description: Chat 20 seconds a day. No forms.
+- CTA button: **Learn More**
+
+**Ad 2 — `predict_graph_reveal`** (visual: knowledge-graph / pattern screenshot)
+- Primary text: *"What if you could see WHY your symptoms keep coming back? ChronicLife connects your symptoms → triggers → patterns into one picture — built from a quick daily chat. Your personal flare forecast. Free beta."*
+- Headline: **See the pattern. Stop the surprise.**
+- Description: Symptoms → triggers → prediction.
+- CTA: **Learn More**
+
+**Ad 3 — `predict_data_proof`** (lead with a stat — boosts trust)
+- Primary text: *"\"Your fatigue increases 40% on days following less than 6 hours of sleep.\" That's the kind of pattern ChronicLife surfaces from your own data — only when it can show the evidence. Chat 20 sec/day, see your forecast. Free during beta."*
+- Headline: **Patterns, backed by your data**
+- Description: We only call a pattern when we can prove it.
+- CTA: **Learn More**
+
+### Meta ad copy — AS2 Spoons (route to `/spoon-saver`)
+
+**Ad 4 — `spoons_tracking_cost`**
+- Primary text: *"Tracking symptoms shouldn't cost spoons you don't have. ChronicLife is a 20-second chat — not a 40-field form. Log how you feel, even on wiped-out days, and let the app remember the rest. Free during beta."*
+- Headline: **Tracking shouldn't cost spoons**
+- Description: 20-second chat. Flare mode for bad days.
+- CTA: **Learn More**
+
+**Ad 5 — `spoons_wiped_mode`**
+- Primary text: *"On the days you can't even look at a screen, ChronicLife has an 'I'm wiped' mode — tap once, done. No guilt, no streak to break. Gentle tracking built for chronic life. Free beta."*
+- Headline: **Built for the days you can't**
+- Description: 'I'm wiped' mode. One tap.
+- CTA: **Learn More**
+
+**Ad 6 — `spoons_chat_not_forms`**
+- Primary text: *"Too tired to track symptoms? Same. So we made it a chat, not a form. Tell Clue how you feel like you'd text a friend — it logs everything and finds the patterns. Free during beta."*
+- Headline: **Chat, don't fill forms**
+- Description: Symptom tracking that respects your energy.
+- CTA: **Learn More**
+
+### Creative direction (use Canva connector + existing ad videos)
+- **Video ads win in this niche.** Repurpose ad1/ad2/ad3 → 9:16 + captions (see `short-form-video-plan.md`).
+- Static fallback: real faces (not stock), warm/dim "in bed / on couch" settings, the knowledge-graph UI screenshot, the "Pattern Detected — based on 14 data points" card.
+- Keep text overlay minimal; native, soft, non-clinical look (Podia-inspired warmth per brand guidelines).
+
+---
+
+## 3. REDDIT campaign (resonance test) — `spoon_saver_v4`
+
+Reuse your strongest existing variants + add prediction. Route to `/spoon-saver` and `/flare-forecast`. Keep headlines **under 7 words** (the 20-Second Rule).
+
+| utm_content | Headline | Angle | Subreddits |
+|---|---|---|---|
+| `tracking_cost_spoons` | Tracking shouldn't cost spoons. | spoons | r/cfs, r/ChronicIllness, r/Fibromyalgia |
+| `chat_not_forms` | Too tired to track? Chat, don't fill forms. | spoons | r/ChronicIllness, r/POTS |
+| `predict_next_flare` | Predict your next flare. | prediction | r/Fibromyalgia, r/migraine, r/LongCOVID |
+| `wiped_mode` | "I'm wiped" mode for bad days. | low-effort | r/cfs, r/MyalgicEncephalomyelitis |
+| `doctor_summaries` | Summaries your doctor will read. | doctor | r/ChronicIllness, r/POTS |
+
+- **Promoted Post** format (looks native) beats banner. Use the spoon photo + one product screenshot.
+- Reddit pixel on landing page if available; otherwise rely on UTM → Supabase → PostHog ABU funnel.
+
+---
+
+## 4. GOOGLE SEARCH campaign (high-intent capture) — `intent_capture_v1`
+
+Tiny budget, best activators. **One ad group, exact + phrase match.**
+
+**Ad group structure:**
+- AG1 [symptom tracker intent]: keywords → RSA1
+
+**Negative keywords:**
+  Campaign-level:
+    - free (we're free but filter freebie-seekers? keep "free" — actually KEEP, we are free) → instead negate:
+    - period tracker
+    - clue app (avoid confusion w/ the period app "Clue")
+    - jobs
+    - ovulation
+  Ad-group level:
+    - AG1: pregnancy, fertility, weather, login
+
+> Note: the period-tracking app **"Clue"** is a major brand. Negate `clue period`, `clue app`, `clue pregnancy` aggressively, and lead with **"ChronicLife"** in headlines to avoid wasted spend + confusion.
+
+**Sitelinks (≥4):**
+  - Flare Forecast | Predict your next flare | See patterns early | https://chroniclife.app/flare-forecast
+  - For Bad Days | 'I'm wiped' mode | One-tap logging | https://chroniclife.app/spoon-saver
+  - Doctor Summaries | Reports doctors read | Clean trends | https://chroniclife.app/crash-prevention
+  - How It Works | Chat 20 sec a day | Free during beta | https://chroniclife.app/
+
+**Callouts (≥4, ≤25 chars):**
+  - 20-second check-ins
+  - Free during beta
+  - Built for brain fog
+  - Doctor-ready summaries
+
+**RSA1 — Chronic symptom tracker**
+  Final URL: https://chroniclife.app/flare-forecast?utm_source=google&utm_medium=cpc&utm_campaign=intent_capture_v1&utm_content=rsa1
+  Path1: symptom-tracker   Path2: chronic
+  Headlines (15, each ≤30 chars):
+    1. ChronicLife Symptom Tracker (27 chars)
+    2. Predict Your Next Flare (23 chars)
+    3. Track Symptoms in 20 Seconds (28 chars)
+    4. Symptom Tracker for Spoonies (28 chars)
+    5. Chat-Based Symptom Tracking (27 chars)
+    6. Built for Brain Fog Days (24 chars)
+    7. See Your Symptom Patterns (25 chars)
+    8. Chronic Illness Tracker App (27 chars)
+    9. Track Flares Without Forms (26 chars)
+    10. Free Symptom Tracker Beta (25 chars)
+    11. Doctor-Ready Symptom Logs (25 chars)
+    12. Tracking That Saves Spoons (26 chars)
+    13. Flare Forecast for Chronic (26 chars)
+    14. Log Symptoms by Chatting (24 chars)
+    15. Know Your Triggers Sooner (25 chars)
+  Descriptions (4, each ≤90 chars):
+    1. Chat 20 seconds a day. ChronicLife learns your patterns and predicts flares early. (83 chars)
+    2. No 40-field forms. Just a quick chat that works on brain-fog days. Free during beta. (84 chars)
+    3. See how symptoms, sleep and triggers connect. Export summaries your doctor will read. (85 chars)
+    4. Built for chronic illness and Spoonies. Gentle tracking that respects your energy. (82 chars)
+  Pinning: H1=position 1 (pin "ChronicLife Symptom Tracker" to avoid period-app confusion); rest unpinned.
+
+---
+
+## 5. Retargeting (Week 4, Meta)
+
+- Audience: site visitors who hit a landing page but **did not** `signup_completed` (7–30 day window).
+- Message: objection-handling + social proof — *"Still thinking about it? It's free, it's 20 seconds, and your data stays yours. See what Clue spots in your first week."*
+- Exclude: anyone who already signed up (`signup_completed`).
+
+---
+
+## 6. Optimization rules (apply every Monday)
+
+- **Judge by cost-per-ABU**, not CPC or CPM. A $1.50 click that never chats is worse than a $4 click that activates.
+- Kill any ad below **0.8% CTR** (Meta) or whose `first_chat_sent` rate is bottom-half after 100+ clicks.
+- Don't touch budgets mid-learning (wait 3–5 days). When scaling, +20–30% only.
+- If CPA high but CTR fine → problem is **post-click** (landing page / signup friction), not the ad.
+- Refresh creative every ~2 weeks to fight fatigue.
+
+---
+
+## 7. What I can execute for you via connectors
+- **Google Ads connector**: create the budget, campaign, ad group, keywords, negatives, and RSA above — ready for your review before enabling.
+- **Facebook Pages connector**: publish organic posts; note paid ad *creation* needs Meta Ads Manager (I'll prep everything copy/targeting-ready).
+- **PostHog**: build the ABU funnel insight.
+- **Canva**: generate the static ad creative set.
+
+Say the word and I'll stand up the Google Search campaign (paused) + PostHog funnel first, since those are fully connector-driven.

--- a/marketing/short-form-video-plan.md
+++ b/marketing/short-form-video-plan.md
@@ -1,0 +1,96 @@
+# Short-Form Video Plan (TikTok / Reels / Shorts)
+
+> Companion to `30-day-beta-growth-plan.md`. Repurpose existing ad videos + add founder content. Chronic-illness TikTok is large, high-empathy, and converts believers.
+> Drafted June 11, 2026.
+
+---
+
+## Strategy in one line
+Post the **same vertical clip to TikTok + Reels + Shorts** 4×/week, lead with the user's emotional truth (not the product), and let the product appear as relief. Bio link → `/spoon-saver` with `utm_source={platform}&utm_medium=social&utm_campaign=shortform_v1`.
+
+## Format spec (non-negotiables)
+- **9:16 vertical**, 15–35 seconds.
+- **Captions always** (85% watch muted) — burned-in, high contrast.
+- **First 3 seconds = pattern interrupt** (a relatable line on screen, no logo).
+- **Native, not polished** — phone-shot energy outperforms ad-agency gloss in this niche.
+- **One CTA** at the end: "Free during beta — link in bio."
+- Reuse your existing `ad1/ad2/ad3` footage as B-roll; the hook + caption do the work.
+
+---
+
+## Hook bank (steal these for the first 3 seconds)
+1. "POV: brain fog ate the last 6 hours and you can't remember a single symptom."
+2. "Things my doctor finally believed once I showed them THIS 👇"
+3. "I tracked my flares for 14 days. On day 15 the app told me one was coming."
+4. "Tracking my symptoms used to cost me a whole spoon. Not anymore."
+5. "If you've abandoned 4 symptom journals, this isn't a you problem."
+6. "Spoonies: stop filling out 40-field forms on your worst days."
+7. "What if your body warned you before a flare?"
+8. "Chronic illness tip nobody tells you about tracking 👇"
+
+---
+
+## 8 ready-to-shoot scripts
+
+### 1 — "Brain fog forgot" (relatability) → /spoon-saver
+- **Hook (0–3s):** [text on screen] "POV: brain fog ate your whole day and you can't remember one symptom."
+- **Body (3–20s):** "So I stopped trying to journal. Now I just text an app how I feel — like texting a friend. 20 seconds. It remembers the rest, even when I can't."
+- **Show:** chat UI, one quick message, "logged."
+- **CTA:** "Free during beta. Link in bio."
+
+### 2 — "Doctor finally believed me" (doctor-proof) → /crash-prevention
+- **Hook:** "Things my doctor finally took seriously once I showed them this."
+- **Body:** "Not a messy diary — a clean summary. Flare episodes, average duration, what helped. Backed by data, not just 'I feel bad.'"
+- **Show:** doctor-summary export card.
+- **CTA:** "It's free right now. Link in bio."
+
+### 3 — "It predicted my flare" (prediction — your hero) → /flare-forecast
+- **Hook:** "I logged symptoms for 14 days. On day 15 it predicted my flare."
+- **Body:** "It noticed my fatigue spikes 40% after bad sleep — something I never connected. Now I get a heads-up and can actually prepare."
+- **Show:** "Pattern Detected — based on 14 data points" card + knowledge graph.
+- **CTA:** "See your own forecast. Free beta, link in bio."
+
+### 4 — "Spoon math" (spoons) → /spoon-saver
+- **Hook:** "Tracking symptoms used to cost me a spoon I didn't have."
+- **Body:** "Long forms on a flare day? Impossible. So this is a chat. On wiped-out days there's an 'I'm wiped' mode — one tap, done. No guilt, no streak to break."
+- **Show:** 'I'm wiped' one-tap flow.
+- **CTA:** "Built for bad days. Link in bio."
+
+### 5 — "4 abandoned journals" (validation) → /spoon-saver
+- **Hook:** "If you've quit 4 symptom journals, it's not a discipline problem."
+- **Body:** "They're built for healthy people with energy. This one's built for us — a 20-second chat that works on the days you can barely move."
+- **CTA:** "Free during beta. Link in bio."
+
+### 6 — "Connect the dots" (pattern) → /top-suspect
+- **Hook:** "What if you could see WHY your symptoms keep coming back?"
+- **Body:** "It connects symptoms → food → sleep → stress into one map. Then points at the top suspect. Mine was stress + poor sleep stacking."
+- **Show:** knowledge graph animation.
+- **CTA:** "Find your top suspect. Link in bio."
+
+### 7 — Founder build-in-public (trust) → /
+- **Hook:** [founder to camera] "I'm building a symptom tracker for chronic illness — here's why the others kept failing people."
+- **Body:** "They treat you like a healthy person with perfect memory and energy. I'm building one that assumes brain fog, fatigue, and bad days are the default. It's a chat. It predicts flares. It's free while I learn from real users."
+- **CTA:** "Try it free, tell me what's broken. Link in bio."
+
+### 8 — "Stat drop" (authority) → /flare-forecast
+- **Hook:** "Your body warns you before a flare. You just can't see it in the moment."
+- **Body:** "From real user data: worst fatigue often follows a bad night's sleep within 24–48 hours. The app catches that lag and tells you. That's the whole point."
+- **CTA:** "See your patterns. Free beta, link in bio."
+
+---
+
+## YouTube long-form (Week 4, 1 video, also feeds AI-search)
+"How flare prediction actually works (and why tracking apps keep failing chronic illness patients)" — 4–7 min explainer. Doubles as AI-citation fuel (YouTube is heavily cited by Google AI Overviews) and a retargeting asset.
+
+---
+
+## Cadence & measurement
+- **4 short clips/week** (Mon/Wed/Fri/Sun), each cross-posted to TikTok + Reels + Shorts.
+- **Reply to every comment** in the first hour (algorithm + trust).
+- Track: views, watch-through, profile/link clicks, and — via UTM → PostHog — which clips drive **ABUs**, not just views.
+- Double down on the format that produces engaged users by Week 3.
+
+## What I can do next
+- **Edit your existing `ad1/ad2/ad3` into captioned 9:16 clips** (media tools) for scripts 1–4.
+- **Generate caption/text overlays + thumbnails** via Canva.
+- **YouTube connector**: publish the long-form explainer + Shorts and pull performance.

--- a/marketing/weekly-logs/README.md
+++ b/marketing/weekly-logs/README.md
@@ -1,0 +1,4 @@
+# Weekly Growth Standup Logs
+
+Each Monday: pull PostHog ABU funnel by utm_content, ad spend/results, log here, decide kill/scale.
+


### PR DESCRIPTION
Adds the marketing knowledge base as the repo record log under /marketing.

Goal: engaged beta users who actually chat & log (Activated Beta Users), not vanity signups. Budget $500/mo.

Files:
- marketing/README.md — index + context + North Star metric (ABU = signup who logs >=1 symptom AND returns within 7 days)
- marketing/30-day-beta-growth-plan.md — master GTM plan (paid + content/SEO + AI-search + short-form video), weekly calendar, success criteria
- marketing/paid-ads-campaign.md — ready-to-ship Meta + Reddit + Google campaigns, copy, targeting, optimization rules
- marketing/content-seo-ai-search-plan.md — 15 target queries, GEO setup, cornerstone articles
- marketing/short-form-video-plan.md — hook bank + 8 scripts repurposing existing ad videos
- marketing/weekly-logs/ — weekly growth-standup logs

Builds on existing campaign_config / UTM / /tracking infra. Everything optimized by cost-per-ABU.